### PR TITLE
Rebuild/0.16.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,10 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - six 1.15.0
-    - bitarray 2.3.5
+    - six 1.16.0
+    - bitarray 2.5.0
     - thrift  # [py2k]
-    - thriftpy2 0.4.16
+    - thriftpy2 0.4
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,10 @@ requirements:
   host:
     - python
     - setuptools
-    - six
-    - bitarray
     - pip
     - wheel
+    - six 1.15.0
+    - bitarray 2.3.5
     - thrift  # [py2k]
     - thriftpy2 0.4.16
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
   description: |
     Python DB API 2.0 client for Impala and Hive (HiveServer2 protocol)
   doc_url: https://pypi.python.org/pypi/impyla
-  doc_source_url: https://github.com/cloudera/impyla/blob/master/README.md
+  dev_url: https://github.com/cloudera/impyla
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - six
     - bitarray
-    - thriftpy2 >=0.3.5
+    - thriftpy2 >=0.4.0,<0.5.0
     - thrift  # [py2k]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
     - setuptools
     - six
     - bitarray
+    - pip
+    - wheel
     - thrift  # [py2k]
     - thriftpy2 0.4.16
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: impyla-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/i/impyla/impyla-{{ version }}.tar.gz
-  md5: 6202a37a16a98473b1c9ec9bbb9a4349
+  sha256: 3fb9a38725cd471833146633aaa9f8916d64035796e7b8dfc6f5a392bef5f184
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - six 1.16.0
+    - six 1.16.0  # [not s390x]
+    - six 1.15.0  # [s390x]
     - bitarray 2.5.0
     - thrift  # [py2k]
     - thriftpy2 0.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,10 @@ requirements:
     - thrift  # [py2k]
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - impala
     - impala.tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
 
   run:
     - python
-    - setuptools
     - six
     - bitarray
     - thriftpy2 >=0.3.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,8 @@ test:
 
 about:
   home: https://github.com/cloudera/impyla
-  license: Apache 2.0
-  license_family: Apache-2.0
+  license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE.txt
   summary: 'Python client for the Impala distributed query engine'
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,11 +44,12 @@ test:
 about:
   home: https://github.com/cloudera/impyla
   license: Apache 2.0
-  license_family: Apache
+  license_family: Apache-2.0
+  license_file: LICENSE.txt
   summary: 'Python client for the Impala distributed query engine'
   description: |
     Python DB API 2.0 client for Impala and Hive (HiveServer2 protocol)
-  doc_url: https://pypi.python.org/pypi/impyla
+  doc_url: https://pypi.org/project/impyla/
   dev_url: https://github.com/cloudera/impyla
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 1
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,11 +19,6 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - six 1.16.0  # [not s390x]
-    - six 1.15.0  # [s390x]
-    - bitarray 2.5.0
-    - thrift  # [py2k]
-    - thriftpy2 0.4
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,14 +20,14 @@ requirements:
     - six
     - bitarray
     - thrift  # [py2k]
-    - thriftpy >=0.3.5
+    - thriftpy2 0.4.16
 
   run:
     - python
     - setuptools
     - six
     - bitarray
-    - thriftpy >=0.3.5
+    - thriftpy2 >=0.3.5
     - thrift  # [py2k]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 6202a37a16a98473b1c9ec9bbb9a4349
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
# Impyla 0.16.3.b1

rebuild to add support for python 3.11

upstream: https://github.com/cloudera/impyla/tree/v0.16.3

## Changes
- Bump build number
- Use `thriftpy2` which is the modern replacement for `thriftpy`
- Correct host pinnings
- Update about section