### PR TITLE
impyla 0.22.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/thrift-feedstock/pr0/efca023

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/thrift-feedstock/pr0/efca023

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.16.3" %}
+{% set version = "0.22.0" %}
 
 package:
   name: impyla
@@ -6,11 +6,11 @@ package:
 
 source:
   fn: impyla-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/i/impyla/impyla-{{ version }}.tar.gz
-  sha256: 3fb9a38725cd471833146633aaa9f8916d64035796e7b8dfc6f5a392bef5f184
+  url: https://pypi.org/packages/source/i/impyla/impyla-{{ version }}.tar.gz
+  sha256: 19def919ef8295a622fdf2f6d04fe1e5954c4d932a397fbde26a89c6c29ef33d
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -19,13 +19,15 @@ requirements:
     - setuptools
     - pip
     - wheel
-
   run:
     - python
     - six
-    - bitarray
+    - bitarray  # [py>=3]
     - thriftpy2 >=0.4.0,<0.5.0
-    - thrift  # [py2k]
+    - thrift ==0.16.0
+    - thrift_sasl ==0.4.3
+  run_constrained:
+    - kerberos >=1.3.0
 
 test:
   requires:
@@ -42,7 +44,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE.txt
-  summary: 'Python client for the Impala distributed query engine'
+  summary: Python client for the Impala distributed query engine
   description: |
     Python DB API 2.0 client for Impala and Hive (HiveServer2 protocol)
   doc_url: https://pypi.org/project/impyla/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - six
-    - bitarray  # [py>=3]
+    - bitarray
     - thriftpy2 >=0.4.0,<0.5.0
     - thrift ==0.16.0
     - thrift_sasl ==0.4.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "impyla" %}
 {% set version = "0.22.0" %}
 
 package:
-  name: impyla
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/i/impyla/impyla-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 19def919ef8295a622fdf2f6d04fe1e5954c4d932a397fbde26a89c6c29ef33d
 
 build:
@@ -33,6 +34,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   imports:
     - impala
     - impala.tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
   summary: Python client for the Impala distributed query engine
   description: |
     Python DB API 2.0 client for Impala and Hive (HiveServer2 protocol)
-  doc_url: https://pypi.org/project/impyla/
+  doc_url: https://pypi.org/project/impyla
   dev_url: https://github.com/cloudera/impyla
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: impyla-{{ version }}.tar.gz
   url: https://pypi.org/packages/source/i/impyla/impyla-{{ version }}.tar.gz
   sha256: 19def919ef8295a622fdf2f6d04fe1e5954c4d932a397fbde26a89c6c29ef33d
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:


### PR DESCRIPTION
impyla 0.22.0 

**Destination channel:** Defaults

### Links

- [PKG-9120]
- dev_url:        https://github.com/cloudera/impyla/tree/v0.22.0
- conda_forge:    https://github.com/conda-forge/impyla-feedstock
- pypi:           https://pypi.org/project/impyla/0.22.0
- pypi inspector: https://inspector.pypi.io/project/impyla/0.22.0

### Explanation of changes:

- new version number


[PKG-9120]: https://anaconda.atlassian.net/browse/PKG-9120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ